### PR TITLE
Add --print-multiline flag on Py3.8+.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,6 +25,12 @@ To use it::
    A Python file or a directory in which to search. Directories will be searched
    recursively for ``.py`` and ``.pyw`` files.
 
+.. option:: -m MAX_LINES, --max-lines MAX_LINES
+
+   By default, on Python >=3.8, multiline matches are fully printed, up to a
+   maximum of 10 lines.  This maximum number of printed lines can be set by
+   this option.  Setting it to 0 disables multiline printing.
+
 .. option:: -l, --files-with-matches
 
    Output only the paths of matching files, not the lines that matched.


### PR DESCRIPTION
Py3.8+ provides Node.end_lineno which is exactly what's needed for the
feature.  Test e.g. with `astsearch -m 'if ??: ??'`.

Closes #6.

I don't have a strong opinion as to how to name the option.